### PR TITLE
Fix Bower install

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "Tomislav Capan <tomislav.capan@gmail.com>"
   ],
   "description": "Speaking URL wrapper for AngularJS",
-  "main": "src/speakingurl.js",
+  "main": "src/angular-speakingurl.js",
   "keywords": [
     "seo",
     "slug",


### PR DESCRIPTION
The `main` attribute in bower.json was incorrectly set to `src/speakingurl.js` which caused the module not being found. Fixed that by changing to `src/angular-speakingurl.js`.
